### PR TITLE
feat: improve constructor to make subclassing easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ In any case you need them, you always have access to the fixture, the native ele
 
 ```typescript
 class MyComponentTester extends ComponentTester<MyComponent> {
-  constructor(fixture: ComponentFixture<MyComponent>) {
-    super(fixture);
+  constructor() {
+    super(MyComponent);
   }
   
   get country() {

--- a/projects/ngx-fixture/src/lib/component-tester.spec.ts
+++ b/projects/ngx-fixture/src/lib/component-tester.spec.ts
@@ -21,121 +21,145 @@ import { TestHtmlElement } from './test-html-element';
 class TestComponent { }
 
 describe('ComponentTester', () => {
-  let tester: ComponentTester<TestComponent>;
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [
         TestComponent
       ]
     });
-
-    tester = ComponentTester.create(TestComponent);
-    tester.detectChanges();
   });
 
-  it('should select existing element and wrap it', () => {
-    expect(tester.element('#svg') instanceof TestElement).toBe(true);
-    expect(tester.element('#a') instanceof TestHtmlElement).toBe(true);
-    expect(tester.element('#input') instanceof TestInput).toBe(true);
-    expect(tester.element('#button') instanceof TestButton).toBe(true);
-    expect(tester.element('#select') instanceof TestSelect).toBe(true);
-    expect(tester.element('#textarea') instanceof TestTextArea).toBe(true);
+  describe('creation', () => {
+    it('should create via constructor with a component type', () => {
+      const tester = new ComponentTester<TestComponent>(TestComponent);
+      expect(tester.fixture instanceof ComponentFixture).toBe(true);
+      expect(tester.fixture.componentInstance instanceof TestComponent).toBe(true);
+    });
+
+    it('should create via constructor with a fixture', () => {
+      const fixture = TestBed.createComponent(TestComponent);
+      const tester = new ComponentTester<TestComponent>(fixture);
+      expect(tester.fixture).toBe(fixture);
+    });
+
+    it('should create via factory method', () => {
+      const tester = ComponentTester.create(TestComponent);
+      expect(tester.fixture instanceof ComponentFixture).toBe(true);
+      expect(tester.fixture.componentInstance instanceof TestComponent).toBe(true);
+    });
   });
 
-  it('should select unexisting element', () => {
-    expect(tester.element('#unexisting')).toBeNull();
-  });
+  describe('usage', () => {
+    let tester: ComponentTester<TestComponent>;
 
-  it('should select existing elements and wrap them', () => {
-    const elements = tester.elements('[id]');
-    expect(elements.length).toBe(6);
-    expect(elements[0] instanceof TestElement).toBe(true);
-    expect(elements[1] instanceof TestHtmlElement).toBe(true);
-    expect(elements[2] instanceof TestInput).toBe(true);
-    expect(elements[3] instanceof TestButton).toBe(true);
-    expect(elements[4] instanceof TestSelect).toBe(true);
-    expect(elements[5] instanceof TestTextArea).toBe(true);
-  });
+    beforeEach(() => {
+      tester = ComponentTester.create(TestComponent);
+      tester.detectChanges();
+    });
 
-  it('should select unexisting elements', () => {
-    const elements = tester.elements('unexisting');
-    expect(elements).toEqual([]);
-  });
+    it('should select existing element and wrap it', () => {
+      expect(tester.element('#svg') instanceof TestElement).toBe(true);
+      expect(tester.element('#a') instanceof TestHtmlElement).toBe(true);
+      expect(tester.element('#input') instanceof TestInput).toBe(true);
+      expect(tester.element('#button') instanceof TestButton).toBe(true);
+      expect(tester.element('#select') instanceof TestSelect).toBe(true);
+      expect(tester.element('#textarea') instanceof TestTextArea).toBe(true);
+    });
 
-  it('should expose fixture', () => {
-    expect(tester.fixture instanceof ComponentFixture).toBe(true);
-  });
+    it('should select unexisting element', () => {
+      expect(tester.element('#unexisting')).toBeNull();
+    });
 
-  it('should expose native element', () => {
-    expect(tester.nativeElement).toBe(tester.fixture.nativeElement);
-  });
+    it('should select existing elements and wrap them', () => {
+      const elements = tester.elements('[id]');
+      expect(elements.length).toBe(6);
+      expect(elements[0] instanceof TestElement).toBe(true);
+      expect(elements[1] instanceof TestHtmlElement).toBe(true);
+      expect(elements[2] instanceof TestInput).toBe(true);
+      expect(elements[3] instanceof TestButton).toBe(true);
+      expect(elements[4] instanceof TestSelect).toBe(true);
+      expect(elements[5] instanceof TestTextArea).toBe(true);
+    });
 
-  it('should expose debug element', () => {
-    expect(tester.debugElement).toBe(tester.fixture.debugElement);
-  });
+    it('should select unexisting elements', () => {
+      const elements = tester.elements('unexisting');
+      expect(elements).toEqual([]);
+    });
 
-  it('should expose component instance', () => {
-    expect(tester.componentInstance).toBe(tester.fixture.componentInstance);
-  });
+    it('should expose fixture', () => {
+      expect(tester.fixture instanceof ComponentFixture).toBe(true);
+    });
 
-  it('should detect changes', () => {
-    spyOn(tester.fixture, 'detectChanges');
+    it('should expose native element', () => {
+      expect(tester.nativeElement).toBe(tester.fixture.nativeElement);
+    });
 
-    tester.detectChanges(true);
+    it('should expose debug element', () => {
+      expect(tester.debugElement).toBe(tester.fixture.debugElement);
+    });
 
-    expect(tester.fixture.detectChanges).toHaveBeenCalledWith(true);
-  });
+    it('should expose component instance', () => {
+      expect(tester.componentInstance).toBe(tester.fixture.componentInstance);
+    });
 
-  it('should select existing input', () => {
-    expect(tester.input('#input') instanceof TestInput).toBe(true);
-    expect(tester.input('#input').attr('id')).toBe('input');
-  });
+    it('should detect changes', () => {
+      spyOn(tester.fixture, 'detectChanges');
 
-  it('should select unexisting input', () => {
-    expect(tester.input('#unexisting')).toBeNull();
-  });
+      tester.detectChanges(true);
 
-  it('should throw when selecting input that is not an input', () => {
-    expect(() => tester.input('#a')).toThrow();
-  });
+      expect(tester.fixture.detectChanges).toHaveBeenCalledWith(true);
+    });
 
-  it('should select existing button', () => {
-    expect(tester.button('#button') instanceof TestButton).toBe(true);
-    expect(tester.button('#button').attr('id')).toBe('button');
-  });
+    it('should select existing input', () => {
+      expect(tester.input('#input') instanceof TestInput).toBe(true);
+      expect(tester.input('#input').attr('id')).toBe('input');
+    });
 
-  it('should select unexisting button', () => {
-    expect(tester.button('#unexisting')).toBeNull();
-  });
+    it('should select unexisting input', () => {
+      expect(tester.input('#unexisting')).toBeNull();
+    });
 
-  it('should throw when selecting button that is not an button', () => {
-    expect(() => tester.button('#a')).toThrow();
-  });
+    it('should throw when selecting input that is not an input', () => {
+      expect(() => tester.input('#a')).toThrow();
+    });
 
-  it('should select existing select', () => {
-    expect(tester.select('#select') instanceof TestSelect).toBe(true);
-    expect(tester.select('#select').attr('id')).toBe('select');
-  });
+    it('should select existing button', () => {
+      expect(tester.button('#button') instanceof TestButton).toBe(true);
+      expect(tester.button('#button').attr('id')).toBe('button');
+    });
 
-  it('should select unexisting select', () => {
-    expect(tester.select('#unexisting')).toBeNull();
-  });
+    it('should select unexisting button', () => {
+      expect(tester.button('#unexisting')).toBeNull();
+    });
 
-  it('should throw when selecting select that is not an select', () => {
-    expect(() => tester.select('#a')).toThrow();
-  });
+    it('should throw when selecting button that is not an button', () => {
+      expect(() => tester.button('#a')).toThrow();
+    });
 
-  it('should select existing textarea', () => {
-    expect(tester.textarea('#textarea') instanceof TestTextArea).toBe(true);
-    expect(tester.textarea('#textarea').attr('id')).toBe('textarea');
-  });
+    it('should select existing select', () => {
+      expect(tester.select('#select') instanceof TestSelect).toBe(true);
+      expect(tester.select('#select').attr('id')).toBe('select');
+    });
 
-  it('should select unexisting textarea', () => {
-    expect(tester.textarea('#unexisting')).toBeNull();
-  });
+    it('should select unexisting select', () => {
+      expect(tester.select('#unexisting')).toBeNull();
+    });
 
-  it('should throw when selecting textarea that is not an textarea', () => {
-    expect(() => tester.textarea('#a')).toThrow();
+    it('should throw when selecting select that is not an select', () => {
+      expect(() => tester.select('#a')).toThrow();
+    });
+
+    it('should select existing textarea', () => {
+      expect(tester.textarea('#textarea') instanceof TestTextArea).toBe(true);
+      expect(tester.textarea('#textarea').attr('id')).toBe('textarea');
+    });
+
+    it('should select unexisting textarea', () => {
+      expect(tester.textarea('#unexisting')).toBeNull();
+    });
+
+    it('should throw when selecting textarea that is not an textarea', () => {
+      expect(() => tester.textarea('#a')).toThrow();
+    });
   });
 });

--- a/projects/ngx-fixture/src/lib/component-tester.ts
+++ b/projects/ngx-fixture/src/lib/component-tester.ts
@@ -15,21 +15,28 @@ import { TestElementQuerier } from './test-element-querier';
 export class ComponentTester<T> {
 
   private querier: TestElementQuerier;
+  private _fixture: ComponentFixture<T>;
 
   /**
    * Creates a component fixture of the given type with the TestBed and wraps it into a ComponentTester
    */
-  static create<T>(type: Type<T>) {
-    const fixture = TestBed.createComponent(type);
+  static create<T>(componentType: Type<T>) {
+    const fixture = TestBed.createComponent(componentType);
     return new ComponentTester(fixture);
   }
 
   /**
-   * Creates a ComponentTester wrapping (and delegating) to the given ComponentFixture
-   * @param fixture the fixture to wrap
+   * Creates a ComponentFixture for the given component type using the TestBed, and creates a ComponentTester
+   * wrapping (and delegating) to this fixture. If a fixture is passed, then delegates to this fixture directly.
+   * @param arg the type of the component to wrap, or a component fixture to wrap
    */
-  constructor(public fixture: ComponentFixture<T>) {
-    this.querier = new TestElementQuerier(this, fixture.nativeElement);
+  constructor(arg: Type<T> | ComponentFixture<T>) {
+    this._fixture = (arg instanceof ComponentFixture) ? arg : TestBed.createComponent(arg);
+    this.querier = new TestElementQuerier(this, this._fixture.nativeElement);
+  }
+
+  get fixture(): ComponentFixture<T> {
+    return this._fixture;
   }
 
   /**

--- a/projects/ngx-fixture/src/lib/test-button.spec.ts
+++ b/projects/ngx-fixture/src/lib/test-button.spec.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { ComponentTester } from './component-tester';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { TestButton } from './test-button';
 
 @Component({
@@ -13,8 +13,8 @@ class TestComponent {
 }
 
 class TestComponentTester extends ComponentTester<TestComponent> {
-  constructor(fixture: ComponentFixture<TestComponent>) {
-    super(fixture);
+  constructor() {
+    super(TestComponent);
   }
 
   get enabledButton() {
@@ -35,7 +35,7 @@ describe('TestButton', () => {
         TestComponent
       ]
     });
-    tester = new TestComponentTester(TestBed.createComponent(TestComponent));
+    tester = new TestComponentTester();
     tester.detectChanges();
   });
 

--- a/projects/ngx-fixture/src/lib/test-element.spec.ts
+++ b/projects/ngx-fixture/src/lib/test-element.spec.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { ComponentTester } from './component-tester';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { TestElement } from './test-element';
 import { TestHtmlElement } from './test-html-element';
 import { TestButton } from './test-button';
@@ -28,8 +28,8 @@ class TestComponent {
 }
 
 class TestComponentTester extends ComponentTester<TestComponent> {
-  constructor(fixture: ComponentFixture<TestComponent>) {
-    super(fixture);
+  constructor() {
+    super(TestComponent);
   }
 
   get svg() {
@@ -50,7 +50,7 @@ describe('TestElement', () => {
         TestComponent
       ]
     });
-    tester = new TestComponentTester(TestBed.createComponent(TestComponent));
+    tester = new TestComponentTester();
     tester.detectChanges();
   });
 

--- a/projects/ngx-fixture/src/lib/test-html-element.spec.ts
+++ b/projects/ngx-fixture/src/lib/test-html-element.spec.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { ComponentTester } from './component-tester';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { TestElement } from './test-element';
 import { TestHtmlElement } from './test-html-element';
 
@@ -14,8 +14,8 @@ class TestComponent {
 }
 
 class TestComponentTester extends ComponentTester<TestComponent> {
-  constructor(fixture: ComponentFixture<TestComponent>) {
-    super(fixture);
+  constructor() {
+    super(TestComponent);
   }
 
   get link() {
@@ -32,7 +32,7 @@ describe('TestElement', () => {
         TestComponent
       ]
     });
-    tester = new TestComponentTester(TestBed.createComponent(TestComponent));
+    tester = new TestComponentTester();
     tester.detectChanges();
   });
 

--- a/projects/ngx-fixture/src/lib/test-input.spec.ts
+++ b/projects/ngx-fixture/src/lib/test-input.spec.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { ComponentTester } from './component-tester';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { TestButton } from './test-button';
+import { TestBed } from '@angular/core/testing';
 import { TestInput } from './test-input';
 
 @Component({
@@ -21,8 +20,8 @@ class TestComponent {
 }
 
 class TestComponentTester extends ComponentTester<TestComponent> {
-  constructor(fixture: ComponentFixture<TestComponent>) {
-    super(fixture);
+  constructor() {
+    super(TestComponent);
   }
 
   get textInput() {
@@ -55,7 +54,7 @@ describe('TestInput', () => {
         TestComponent
       ]
     });
-    tester = new TestComponentTester(TestBed.createComponent(TestComponent));
+    tester = new TestComponentTester();
     tester.detectChanges();
   });
 

--- a/projects/ngx-fixture/src/lib/test-select.spec.ts
+++ b/projects/ngx-fixture/src/lib/test-select.spec.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { ComponentTester } from './component-tester';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { TestButton } from './test-button';
 import { TestSelect } from './test-select';
 
@@ -18,8 +18,8 @@ class TestComponent {
 }
 
 class TestComponentTester extends ComponentTester<TestComponent> {
-  constructor(fixture: ComponentFixture<TestComponent>) {
-    super(fixture);
+  constructor() {
+    super(TestComponent);
   }
 
   get selectBox() {
@@ -36,7 +36,7 @@ describe('TestButton', () => {
         TestComponent
       ]
     });
-    tester = new TestComponentTester(TestBed.createComponent(TestComponent));
+    tester = new TestComponentTester();
     tester.detectChanges();
   });
 

--- a/projects/ngx-fixture/src/lib/test-textarea.spec.ts
+++ b/projects/ngx-fixture/src/lib/test-textarea.spec.ts
@@ -1,8 +1,6 @@
 import { Component } from '@angular/core';
 import { ComponentTester } from './component-tester';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { TestButton } from './test-button';
-import { TestInput } from './test-input';
+import { TestBed } from '@angular/core/testing';
 import { TestTextArea } from './test-textarea';
 
 @Component({
@@ -16,8 +14,8 @@ class TestComponent {
 }
 
 class TestComponentTester extends ComponentTester<TestComponent> {
-  constructor(fixture: ComponentFixture<TestComponent>) {
-    super(fixture);
+  constructor() {
+    super(TestComponent);
   }
 
   get textBox() {
@@ -34,7 +32,7 @@ describe('TestTextArea', () => {
         TestComponent
       ]
     });
-    tester = new TestComponentTester(TestBed.createComponent(TestComponent));
+    tester = new TestComponentTester();
     tester.detectChanges();
   });
 


### PR DESCRIPTION
⚠️ Don't merge

Although this seems like a stupid, innocent change, and although the unit tests pass, building this branch and using it in globe42 makes the tests using ngx-fixture fail, for a reason I really can't understand.

I know that the error, in 99.9 %, is on our side, but I'm starting to think there is a bug in Angular, or Webpack, or Zone.js, or whatever (not Chrome, because the tests also fail in Firefox)

Here's the stack trace of one of these failures:

```
HeadlessChrome 0.0.0 (Mac OS X 10.13.4) TasksComponent UI should invoke actions FAILED
	TypeError: Cannot read property 'getComponentFromError' of null
	    at TestBed.push.../../ngx-fixture/node_modules/@angular/core/fesm5/testing.js.TestBed._initIfNeeded Users/jb/projects/ngx-fixture/node_modules/@angular/core/fesm5/testing.js:1145:1)
	    at TestBed.push.../../ngx-fixture/node_modules/@angular/core/fesm5/testing.js.TestBed.createComponent Users/jb/projects/ngx-fixture/node_modules/@angular/core/fesm5/testing.js:1346:1)
	    at Function.push.../../ngx-fixture/node_modules/@angular/core/fesm5/testing.js.TestBed.createComponent Users/jb/projects/ngx-fixture/node_modules/@angular/core/fesm5/testing.js:996:1)
	    at TasksComponentTester.ComponentTester Users/jb/projects/ngx-fixture/dist/ngx-fixture/fesm5/ngx-fixture.js:878:1)
	    at new TasksComponentTester src/app/tasks/tasks.component.spec.ts:39:5)
	    at UserContext.<anonymous> src/app/tasks/tasks.component.spec.ts:193:16)
	    at ZoneDelegate../node_modules/zone.js/dist/zone.js.ZoneDelegate.invoke node_modules/zone.js/dist/zone.js:388:1)
	    at ProxyZoneSpec.push../node_modules/zone.js/dist/zone-testing.js.ProxyZoneSpec.onInvoke node_modules/zone.js/dist/zone-testing.js:288:1)
	    at ZoneDelegate../node_modules/zone.js/dist/zone.js.ZoneDelegate.invoke node_modules/zone.js/dist/zone.js:387:1)
	    at Zone../node_modules/zone.js/dist/zone.js.Zone.run node_modules/zone.js/dist/zone.js:138:1)
```

@cexbrayat if you have a clue...